### PR TITLE
Changed security check in ADC_ConfigGetRanksOfChannels

### DIFF
--- a/ADC/Src/adc_driver.c
+++ b/ADC/Src/adc_driver.c
@@ -74,7 +74,7 @@ HAL_StatusTypeDef ADC_Init(ADC_HandleTypeDef* hadc, ADC_BufferTypeDef* badc, ADC
 			if(__ADC_IS_DMA_ENABLED(hadc) != 0){
 
 				// starting DMA with ADC in Independent mode
-				if(HAL_ADC_Start_DMA(hadc, (uint32_t*)badc->idma.BufferADC, ADC_CONVERTED_CHANNELS) != HAL_OK){
+				if(HAL_ADC_Start_DMA(hadc, (uint32_t*)badc->idma.BufferADC, ADC_BUFF_SIZE) != HAL_OK){
 					return HAL_ERROR;
 				}
 			}
@@ -108,7 +108,7 @@ HAL_StatusTypeDef ADC_InitMultimode(ADC_HandleTypeDef* hadcMaster, ADC_BufferTyp
 	}
 
 	// launching dual mode conversion
-	if(HAL_ADCEx_MultiModeStart_DMA(hadcMaster, badc->ddma.BufferMultiMode, ADC_CONVERTED_CHANNELS) != HAL_OK){
+	if(HAL_ADCEx_MultiModeStart_DMA(hadcMaster, badc->ddma.BufferMultiMode, ADC_BUFF_SIZE) != HAL_OK){
 		return HAL_ERROR;
 	}
 
@@ -215,7 +215,7 @@ HAL_StatusTypeDef ADC_ReadChannel(ADC_HandleTypeDef* hadc, ADC_ChannelsTypeDef* 
 
 			// re-launching ADC in dual mode conversion with DMA
 			if(__ADC_DMA_MODE(hadc) == 0){
-				if(HAL_ADCEx_MultiModeStart_DMA(hadc, badc->ddma.BufferMultiMode, ADC_CONVERTED_CHANNELS) != HAL_OK){
+				if(HAL_ADCEx_MultiModeStart_DMA(hadc, badc->ddma.BufferMultiMode, ADC_BUFF_SIZE) != HAL_OK){
 					return HAL_ERROR;
 				}
 			}
@@ -224,7 +224,7 @@ HAL_StatusTypeDef ADC_ReadChannel(ADC_HandleTypeDef* hadc, ADC_ChannelsTypeDef* 
 
 			// re-launching ADC in independent conversion with DMA
 			if(__ADC_DMA_MODE(hadc) != 0){
-				if(HAL_ADC_Start_DMA(hadc, (uint32_t*)badc->idma.BufferADC, ADC_CONVERTED_CHANNELS) != HAL_OK){
+				if(HAL_ADC_Start_DMA(hadc, (uint32_t*)badc->idma.BufferADC, ADC_BUFF_SIZE) != HAL_OK){
 					return HAL_ERROR;
 				}
 			}
@@ -286,7 +286,7 @@ HAL_StatusTypeDef  ADC_ConfigGetRanksOfChannels(ADC_HandleTypeDef* hadc, ADC_Cha
 
 	// Security check
 
-	if(numberOfConversions >= ADC_MAX_CHANNELS){
+	if(numberOfConversions > ADC_MAX_CHANNELS){
 		return HAL_ERROR;
 	}
 


### PR DESCRIPTION
Now driver requires changing  manually macro's stored value. ADC_MAX_CHANNELS should contains real number of channels, wich will be used. Thanks to that, DMA buffer will store converted values in correct order.