### PR TITLE
Fixed PWM logic + a bit of code cleanup

### DIFF
--- a/PWM/Inc/pwm_driver.h
+++ b/PWM/Inc/pwm_driver.h
@@ -10,11 +10,11 @@ typedef struct {
     uint32_t Frequency;
     float PWM_Width;
     bool Read_Flag;
+    volatile uint32_t IC_Val1;
+    volatile uint32_t IC_Val2;
+    volatile uint8_t Capture_count;
+    float Widths[5];
 } PWM_Signal;
-
-extern volatile uint32_t IC_Val1;
-extern volatile uint32_t IC_Val2;
-extern volatile uint8_t Capture_count;
 
 void PWM_Initialize(PWM_Signal* signal, int frequency);
 void PWM_Update(TIM_HandleTypeDef *htim, PWM_Signal *PWM, uint32_t channel);

--- a/PWM/Src/pwm_driver.c
+++ b/PWM/Src/pwm_driver.c
@@ -6,35 +6,44 @@
 #include <string.h>
 #include <stdio.h>
 
-volatile uint32_t IC_Val1 = 0;
-volatile uint32_t IC_Val2 = 0;
-volatile uint8_t Capture_count = 0;
 
 void PWM_Initialize(PWM_Signal* signal,int frequency) {
-	signal->PWM_Width = 69.f;
+	signal->PWM_Width = 0.f;
 	signal->Read_Flag = false;
 	signal->Frequency = frequency;
+	signal->Capture_count = 0;
+	signal->Widths[0] = 0.f;
+	signal->Widths[1] = 0.f;
+	signal->Widths[2] = 0.f;
+	signal->Widths[3] = 0.f;
+	signal->Widths[4] = 0.f;
 }
+
 
 
 void PWM_Update(TIM_HandleTypeDef *htim, PWM_Signal *PWM, uint32_t channel)
 {
-    if (Capture_count == 0)
+    if (PWM->Capture_count == 0)
     {
-        IC_Val1 = HAL_TIM_ReadCapturedValue(htim, channel);
+    	PWM->IC_Val1 = HAL_TIM_ReadCapturedValue(htim, channel);
         if (PWM->Read_Flag)
         {
-            PWM->PWM_Width = (float)IC_Val2 / ((float)IC_Val1);
+        	PWM->Widths[4] = PWM->Widths[3];
+            PWM->Widths[3] = PWM->Widths[2];
+			PWM->Widths[2] = PWM->Widths[1];
+		    PWM->Widths[1] = PWM->Widths[0];
+            PWM->Widths[0] = (float)(PWM->IC_Val2) / ((float)PWM->IC_Val1);
+        	PWM->PWM_Width = (PWM->Widths[0]+PWM->Widths[1]+PWM->Widths[2]+PWM->Widths[3]+PWM->Widths[4])/(float)(5);
         }
         __HAL_TIM_SET_COUNTER(htim, 0);
         __HAL_TIM_SET_CAPTUREPOLARITY(htim, channel, TIM_INPUTCHANNELPOLARITY_FALLING);
-        Capture_count = 1;
+        PWM->Capture_count = 1;
     }
     else
     {
-        IC_Val2 = HAL_TIM_ReadCapturedValue(htim, channel);
+    	PWM->IC_Val2 = HAL_TIM_ReadCapturedValue(htim, channel);
         __HAL_TIM_SET_CAPTUREPOLARITY(htim, channel, TIM_INPUTCHANNELPOLARITY_RISING);
-        Capture_count = 0;
+        PWM->Capture_count = 0;
     }
 
     PWM->Read_Flag = true;


### PR DESCRIPTION
Fixed bugs from pervious iteration, now using the avarage of last 5 read signal as PWM_width. Code still needs a lot of cleanup (and comments) to comply and some work on better handling of missed PWM signals, they can still cause occasional signal widths to be widely off.