### PR TITLE
ADC_Driver: Fixed macro defitinion while reading ADC resolution of F3 cores. Fixed error: multiple defitinion of ADC_CFGR_Res_Msk

### DIFF
--- a/ADC/Inc/adc_conf.h
+++ b/ADC/Inc/adc_conf.h
@@ -21,14 +21,27 @@
 
 #pragma once
 
+#include "adc.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-/* Private constant macros -------------------------------------------------------------------------------------------- */
+/* Public constant macros -------------------------------------------------------------------------------------------- */
+
+/*
+ * ADC1 configuration macros section
+ */
 #define ADC1_USED_CHANNELS (3)  //< Macro defines number of channels for ADC1,
+#define ADC1_SAMPLING      (4)  //< Macro defines number of measures of one channel to be averaged
+
+/*
+ * ADC2 configuration macros section
+ */
 #define ADC2_USED_CHANNELS (3)  //< Macro defines number of channels for ADC2,
+#define ADC2_SAMPLING      (4)  //< Macro defines number of measures of one channel to be averaged
+
 
 #ifdef __cplusplus
 }

--- a/ADC/Inc/adc_conf.h
+++ b/ADC/Inc/adc_conf.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "adc.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/ADC/Inc/adc_utils.h
+++ b/ADC/Inc/adc_utils.h
@@ -40,7 +40,7 @@
     #define ADC_SQR1_4_OFFSET     (14)       //< Offset in reading SQR3 reg of ADC - used in shifting bits while reading ranks 10 - 14, cause for loop would trigger end of bound error
     #define ADC_SQR_DATA_RES      (6)        //< Resolution of channel number in regs - generally 5 bits of data
     #define ADC_SQR1_L_OFFSET     (1)        //< Offset in reading SQR1 reg of ADC, because on first bits of SQR1 L data is stored
-    #define ADC_CFGR_RES_Msk      (0x3)      //< Data resolution of stored ADC's resolution param
+    #define ADC_CFGR_RES_Mask      (0x3)      //< Data resolution of stored ADC's resolution param
 #endif
 
 #define ADC_SQR_DATA_Msk          (0x1F)     //< Mask for channel number in regs - generally 4:0 bits of data so 11111

--- a/ADC/Src/adc_utils.c
+++ b/ADC/Src/adc_utils.c
@@ -118,7 +118,7 @@ uint16_t ADC_Resolution(ADC_HandleTypeDef* hadc){
        return (4095);
    #elif defined(STM32F3_FAMILY)
 
-       uint8_t res = (uint16_t)((hadc->Instance->CFGR >> ADC_CFGR_RES_Pos) & ADC_CFGR_RES_Msk);
+       uint8_t res = (uint16_t)((hadc->Instance->CFGR >> ADC_CFGR_RES_Pos) & ADC_CFGR_RES_Mask);
 
        return ((res == 0x0) ? 4095 : ((res == 0x1) ? 1023 : ((res == 0x2) ? 255 : 63)));
 


### PR DESCRIPTION
Fix: Changed macro mask definition (changed name) to prevent from multiple definition while Reading ADC resolution of F3 cores