### PR TITLE
Adds FIFO buffer for incoming CAN messages

### DIFF
--- a/CAN/Inc/can_driver.h
+++ b/CAN/Inc/can_driver.h
@@ -11,6 +11,7 @@
 #include "can_id_list.h"
 #include "main.h"
 #include <stdio.h>
+#include "string.h"
 
 /**
  * Defines

--- a/CAN/Inc/can_driver.h
+++ b/CAN/Inc/can_driver.h
@@ -17,7 +17,7 @@
  */
 
 #define CAN_MAX_DLC (8)
-#define CAN_MAX_MSG (8)
+#define CAN_MAX_MSG (32)
 
 /**
  * @brief Generic macro to swap endianness based on variable type.~
@@ -120,7 +120,7 @@ void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList
  * @param buffer   Pointer to the buffer that holds messages
  * @retval HAL_StatusTypeDef   State of the operation
  */
-HAL_StatusTypeDef CAN_AddScheduledMsg(const struct CAN_scheduledMsg *msg, struct CAN_scheduledMsgList *buffer);
+HAL_StatusTypeDef CAN_AddScheduledMsg(struct CAN_scheduledMsg *msg, struct CAN_scheduledMsgList *buffer);
 
 /**
  * @brief Remove message from the periodic buffer
@@ -140,7 +140,7 @@ HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgLis
  * @param data    Pointer to received CAN payload
  * @retval HAL_StatusTypeDef   State of the operation
  */
-HAL_StatusTypeDef CAN_AddIncomingMessage(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data);
+HAL_StatusTypeDef CAN_AddIncomingMsg(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data);
 
 /**
  * @brief Read the oldest incoming CAN message from the FIFO buffer

--- a/CAN/Inc/can_driver.h
+++ b/CAN/Inc/can_driver.h
@@ -17,7 +17,7 @@
  */
 
 #define CAN_MAX_DLC (8)
-#define CAN_MAX_MSG (32)
+#define CAN_MAX_MSG (8)
 
 /**
  * @brief Generic macro to swap endianness based on variable type.~
@@ -70,29 +70,48 @@ struct CAN_scheduledMsgList
 };
 
 /**
+ * Incoming CAN message
+ */
+struct CAN_IncomingMsg
+{
+	CAN_RxHeaderTypeDef header;
+	uint8_t data[CAN_MAX_DLC];
+};
+
+/**
+ * Incoming CAN message buffer
+ */
+struct CAN_IncomingMsgList
+{
+	struct CAN_IncomingMsg list[CAN_MAX_MSG];
+	uint8_t head;
+	uint8_t tail;
+	uint8_t count;
+	uint8_t receiveFlag;
+};
+
+/**
  * Setup functions
  */
 
 /**
- * @brief Initialize CAN
+ * @brief Initialize CAN peripheral
  *
- * This function initializes the CAN peripheral.
- *
- * @param hcan      Pointer to CAN handle
+ * @param hcanPtr   Pointer to CAN handle
  */
 void CAN_Init(CAN_HandleTypeDef *hcan);
 
 /**
+ * Functions for scheduled messages
+ */
+
+ /**
  * @brief Process all scheduled CAN messages (call in main loop)
  *
  * @param hcanPtr      Pointer to CAN handle
  * @param scheduler    Pointer to the message scheduler
  */
 void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList *scheduler);
-
-/**
- * Functions for scheduled messages
- */
 
 /**
  * @brief Add new message to the periodic buffer
@@ -111,5 +130,24 @@ HAL_StatusTypeDef CAN_AddScheduledMsg(const struct CAN_scheduledMsg *msg, struct
  * @retval HAL_StatusTypeDef   State of the operation
  */
 HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgList *buffer);
+
+/* Incoming CAN message buffer */
+
+/**
+ * @brief Add incoming CAN message to the FIFO buffer
+ *
+ * @param header  Pointer to received CAN header
+ * @param data    Pointer to received CAN payload
+ * @retval HAL_StatusTypeDef   State of the operation
+ */
+HAL_StatusTypeDef CAN_AddIncomingMessage(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data);
+
+/**
+ * @brief Read the oldest incoming CAN message from the FIFO buffer
+ *
+ * @param msg  Pointer to storage for the received message
+ * @retval HAL_StatusTypeDef   State of the operation
+ */
+HAL_StatusTypeDef CAN_GetLatestMessage(struct CAN_IncomingMsgList *buffer, struct CAN_IncomingMsg *msg);
 
 #endif /* CAN_DRIVER_H */

--- a/CAN/Src/can_driver.c
+++ b/CAN/Src/can_driver.c
@@ -23,11 +23,6 @@
 #define ERROR_HANDLER_AVAILABLE (0)
 #endif
 
-/**
- * @brief Initialize CAN peripheral
- *
- * @param hcanPtr   Pointer to CAN handle
- */
 void CAN_Init(CAN_HandleTypeDef *hcanPtr)
 {
 	if (HAL_CAN_ActivateNotification(hcanPtr, CAN_IT_RX_FIFO0_MSG_PENDING) != HAL_OK)
@@ -60,13 +55,6 @@ void CAN_Init(CAN_HandleTypeDef *hcanPtr)
 	}
 }
 
-/**
- * @brief Add new message to the periodic buffer
- *
- * @param msg      Pointer to the message to add
- * @param buffer   Pointer to the buffer that holds messages
- * @retval HAL_StatusTypeDef   State of the operation
- */
 HAL_StatusTypeDef CAN_AddScheduledMsg(const struct CAN_scheduledMsg *msg, struct CAN_scheduledMsgList *buffer)
 {
 	// basic error checking
@@ -97,13 +85,6 @@ HAL_StatusTypeDef CAN_AddScheduledMsg(const struct CAN_scheduledMsg *msg, struct
 	return HAL_OK;
 }
 
-/**
- * @brief Remove message from the periodic buffer
- *
- * @param id       ID of the message to remove
- * @param buffer   Pointer to the buffer that holds messages
- * @retval HAL_StatusTypeDef   State of the operation
- */
 HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgList *buffer)
 {
 	for (uint8_t i = 0; i < buffer->size; i++)
@@ -124,12 +105,6 @@ HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgLis
 	return HAL_ERROR;
 }
 
-/**
- * @brief Process all scheduled CAN messages (call in main loop)
- *
- * @param hcanPtr      Pointer to CAN handle
- * @param scheduler    Pointer to the message scheduler
- */
 void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList *scheduler)
 {
 	if (hcanPtr == NULL || scheduler == NULL)
@@ -163,4 +138,52 @@ void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList
 			msg->lastTick = HAL_GetTick();
 		}
 	}
+}
+
+HAL_StatusTypeDef CAN_AddIncomingMessage(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data)
+{
+	if (buffer == NULL)
+	{
+		return HAL_ERROR;
+	}
+
+	if (buffer->count >= CAN_MAX_MSG)
+	{
+		Error_Handler();
+		return HAL_ERROR;
+	}
+
+	struct CAN_IncomingMsg *dst = &buffer->list[buffer->head];
+	dst->header = *header;
+	memcpy(dst->data, data, CAN_MAX_DLC);
+
+	buffer->head = (buffer->head + 1) % CAN_MAX_MSG;
+	buffer->count++;
+	buffer->receiveFlag = 1;
+
+	return HAL_OK;
+}
+
+HAL_StatusTypeDef CAN_GetLatestMessage(struct CAN_IncomingMsgList *buffer, struct CAN_IncomingMsg *msg)
+{
+	if (buffer == NULL || msg == NULL)
+	{
+		return HAL_ERROR;
+	}
+
+	if (buffer->count == 0)
+	{
+		return HAL_ERROR;
+	}
+
+	*msg = buffer->list[buffer->tail];
+	buffer->tail = (buffer->tail + 1) % CAN_MAX_MSG;
+	buffer->count--;
+
+	if (buffer->count == 0)
+	{
+		buffer->receiveFlag = 0;
+	}
+
+	return HAL_OK;
 }

--- a/CAN/Src/can_driver.c
+++ b/CAN/Src/can_driver.c
@@ -60,11 +60,11 @@ HAL_StatusTypeDef CAN_AddScheduledMsg(struct CAN_scheduledMsg *msg, struct CAN_s
 	// basic error checking
 	if (buffer->size >= CAN_MAX_MSG)
 	{
-		Error_Handler();
+		return HAL_ERROR;
 	}
 	if (msg->periodMs == 0)
 	{
-		Error_Handler();
+		return HAL_ERROR;
 	}
 
 	struct CAN_scheduledMsg tempMsg = *msg;

--- a/CAN/Src/can_driver.c
+++ b/CAN/Src/can_driver.c
@@ -55,7 +55,7 @@ void CAN_Init(CAN_HandleTypeDef *hcanPtr)
 	}
 }
 
-HAL_StatusTypeDef CAN_AddScheduledMsg(const struct CAN_scheduledMsg *msg, struct CAN_scheduledMsgList *buffer)
+HAL_StatusTypeDef CAN_AddScheduledMsg(struct CAN_scheduledMsg *msg, struct CAN_scheduledMsgList *buffer)
 {
 	// basic error checking
 	if (buffer->size >= CAN_MAX_MSG)
@@ -140,7 +140,7 @@ void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList
 	}
 }
 
-HAL_StatusTypeDef CAN_AddIncomingMessage(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data)
+HAL_StatusTypeDef CAN_AddIncomingMsg(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data)
 {
 	if (buffer == NULL)
 	{
@@ -149,7 +149,6 @@ HAL_StatusTypeDef CAN_AddIncomingMessage(struct CAN_IncomingMsgList *buffer, CAN
 
 	if (buffer->count >= CAN_MAX_MSG)
 	{
-		Error_Handler();
 		return HAL_ERROR;
 	}
 


### PR DESCRIPTION
Introduces a dedicated FIFO structure and functions to handle incoming CAN messages, enabling efficient buffering and retrieval. Reduces the maximum scheduled message buffer size to optimize resource usage. Improves modularity and prepares for more robust CAN reception handling.