### PR TITLE
LED master/slave sync

### DIFF
--- a/CAN/Inc/can_driver.h
+++ b/CAN/Inc/can_driver.h
@@ -85,8 +85,6 @@ struct CAN_IncomingMsg
 struct CAN_IncomingMsgList
 {
 	struct CAN_IncomingMsg list[CAN_MAX_MSG];
-	uint8_t head;
-	uint8_t tail;
 	uint8_t count;
 	uint8_t receiveFlag;
 };
@@ -135,7 +133,7 @@ HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgLis
 /* Incoming CAN message buffer */
 
 /**
- * @brief Add incoming CAN message to the FIFO buffer
+ * @brief Add incoming CAN message to the buffer
  *
  * @param header  Pointer to received CAN header
  * @param data    Pointer to received CAN payload
@@ -144,7 +142,7 @@ HAL_StatusTypeDef CAN_RemoveScheduledMsg(uint32_t id, struct CAN_scheduledMsgLis
 HAL_StatusTypeDef CAN_AddIncomingMsg(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data);
 
 /**
- * @brief Read the oldest incoming CAN message from the FIFO buffer
+ * @brief Read and remove the pending message with the lowest CAN ID
  *
  * @param msg  Pointer to storage for the received message
  * @retval HAL_StatusTypeDef   State of the operation

--- a/CAN/Src/can_driver.c
+++ b/CAN/Src/can_driver.c
@@ -140,9 +140,19 @@ void CAN_HandleScheduled(CAN_HandleTypeDef *hcanPtr, struct CAN_scheduledMsgList
 	}
 }
 
+static uint32_t CAN_GetIncomingMsgId(const CAN_RxHeaderTypeDef *header)
+{
+	if (header->IDE == CAN_ID_STD)
+	{
+		return header->StdId;
+	}
+
+	return header->ExtId;
+}
+
 HAL_StatusTypeDef CAN_AddIncomingMsg(struct CAN_IncomingMsgList *buffer, CAN_RxHeaderTypeDef *header, uint8_t *data)
 {
-	if (buffer == NULL)
+	if (buffer == NULL || header == NULL || data == NULL)
 	{
 		return HAL_ERROR;
 	}
@@ -152,11 +162,10 @@ HAL_StatusTypeDef CAN_AddIncomingMsg(struct CAN_IncomingMsgList *buffer, CAN_RxH
 		return HAL_ERROR;
 	}
 
-	struct CAN_IncomingMsg *dst = &buffer->list[buffer->head];
+	struct CAN_IncomingMsg *dst = &buffer->list[buffer->count];
 	dst->header = *header;
 	memcpy(dst->data, data, CAN_MAX_DLC);
 
-	buffer->head = (buffer->head + 1) % CAN_MAX_MSG;
 	buffer->count++;
 	buffer->receiveFlag = 1;
 
@@ -175,8 +184,21 @@ HAL_StatusTypeDef CAN_GetLatestMessage(struct CAN_IncomingMsgList *buffer, struc
 		return HAL_ERROR;
 	}
 
-	*msg = buffer->list[buffer->tail];
-	buffer->tail = (buffer->tail + 1) % CAN_MAX_MSG;
+	uint8_t lowestIdx = 0;
+	uint32_t lowestId = CAN_GetIncomingMsgId(&buffer->list[0].header);
+
+	for (uint8_t i = 1; i < buffer->count; i++)
+	{
+		uint32_t id = CAN_GetIncomingMsgId(&buffer->list[i].header);
+		if (id < lowestId)
+		{
+			lowestId = id;
+			lowestIdx = i;
+		}
+	}
+
+	*msg = buffer->list[lowestIdx];
+	buffer->list[lowestIdx] = buffer->list[buffer->count - 1];
 	buffer->count--;
 
 	if (buffer->count == 0)

--- a/LED/Inc/led_driver.h
+++ b/LED/Inc/led_driver.h
@@ -5,7 +5,7 @@
  * @author Kacper Lasota
  *
  * This module provides a simple non-blocking LED state machine with
- * off, on and blinking modes.
+ * off, on and blinking modes synchronized via a shared syncTick counter.
  */
 #ifndef LED_DRIVER_H
 #define LED_DRIVER_H
@@ -17,49 +17,58 @@
  * @brief LED behavior states for LED driver.
  */
 typedef enum {
-    LED_OFF = 0,        /**< LED is turned off */
+    LED_OFF = 0,          /**< LED is turned off */
     LED_FAST_BLINK = 100, /**< LED toggles at fast blink interval (ms) */
-    LED_BLINK = 1000,    /**< LED toggles at regular blink interval (ms) */
-    LED_ON = 1001       /**< LED is permanently on (treated as stable state) */
+    LED_BLINK = 1000,     /**< LED toggles at regular blink interval (ms) */
+    LED_ON = 1001         /**< LED is permanently on (treated as stable state) */
 } LED_STATE_e;
 
 /**
  * @struct LED
  * @brief LED driver context structure.
  */
-struct LED{
-    LED_STATE_e state;        /**< Current LED state */
-    GPIO_TypeDef* GPIO_Port;  /**< STM32 GPIO port */
+struct LED {
+    LED_STATE_e state;       /**< Current LED state */
+    GPIO_TypeDef *GPIO_Port; /**< STM32 GPIO port */
     uint16_t GPIO_Pin;       /**< STM32 GPIO pin */
-    uint32_t lastTick;        /**< Unused; kept for struct layout compatibility */
 };
 
 /**
- * @brief Update the network tick used to synchronize LED blinks.
- * @param tick Network-wide tick in milliseconds (e.g. from a CAN message).
+ * @brief Increment the shared sync tick (call from HAL_IncTick).
  *
- * Call this whenever a sync tick is received on the CAN bus. The driver
- * extrapolates time locally between updates so blinking continues on slaves.
- * Re-call periodically to stay in phase across boards.
+ * Hook this into HAL_IncTick so syncTick advances once per millisecond:
+ * @code
+ * void HAL_IncTick(void)
+ * {
+ *     uwTick += uwTickFreq;
+ *     LED_IncSyncTick();
+ * }
+ * @endcode
+ */
+void LED_IncSyncTick(void);
+
+/**
+ * @brief Overwrite syncTick (e.g. when a slave receives it on CAN).
+ * @param tick Network-wide tick in milliseconds.
  */
 void LED_SetSyncTick(uint32_t tick);
 
 /**
- * @brief Process LED behavior based on state and timing.
+ * @brief Read the current sync tick (e.g. for broadcasting on CAN).
+ * @return Current syncTick value.
+ */
+uint32_t LED_GetSyncTick(void);
+
+/**
+ * @brief Process LED behavior based on state and syncTick phase.
  * @param led Pointer to LED context.
- *
- * This function should be called periodically from a main loop or timer.
- * In blinking modes it drives the GPIO from the network sync tick when set
- * via LED_SetSyncTick(), otherwise from HAL_GetTick().
  */
 void LED_Handle(struct LED *led);
 
 /**
  * @brief Apply LED state change and GPIO output.
  * @param led Pointer to LED context.
- *
- * This function updates the actual GPIO output according to the
- * selected state. Blinking modes align to the current sync tick phase.
+ * @param state New LED state.
  */
 void LED_ChangeState(struct LED *led, LED_STATE_e state);
 

--- a/LED/Inc/led_driver.h
+++ b/LED/Inc/led_driver.h
@@ -31,15 +31,25 @@ struct LED{
     LED_STATE_e state;        /**< Current LED state */
     GPIO_TypeDef* GPIO_Port;  /**< STM32 GPIO port */
     uint16_t GPIO_Pin;       /**< STM32 GPIO pin */
-    uint32_t lastTick;        /**< HAL tick snapshot for blink timing */
+    uint32_t lastTick;        /**< Unused; kept for struct layout compatibility */
 };
+
+/**
+ * @brief Update the network tick used to synchronize LED blinks.
+ * @param tick Network-wide tick in milliseconds (e.g. from a CAN message).
+ *
+ * Call this whenever a sync tick is received on the CAN bus. All boards
+ * sharing the same tick will blink in phase.
+ */
+void LED_SetSyncTick(uint32_t tick);
 
 /**
  * @brief Process LED behavior based on state and timing.
  * @param led Pointer to LED context.
  *
  * This function should be called periodically from a main loop or timer.
- * It toggles the LED state when in blinking modes based on HAL_GetTick().
+ * In blinking modes it drives the GPIO from the network sync tick when set
+ * via LED_SetSyncTick(), otherwise from HAL_GetTick().
  */
 void LED_Handle(struct LED *led);
 
@@ -48,7 +58,7 @@ void LED_Handle(struct LED *led);
  * @param led Pointer to LED context.
  *
  * This function updates the actual GPIO output according to the
- * selected state and resets the timing reference for blinking.
+ * selected state. Blinking modes align to the current sync tick phase.
  */
 void LED_ChangeState(struct LED *led, LED_STATE_e state);
 

--- a/LED/Inc/led_driver.h
+++ b/LED/Inc/led_driver.h
@@ -38,8 +38,9 @@ struct LED{
  * @brief Update the network tick used to synchronize LED blinks.
  * @param tick Network-wide tick in milliseconds (e.g. from a CAN message).
  *
- * Call this whenever a sync tick is received on the CAN bus. All boards
- * sharing the same tick will blink in phase.
+ * Call this whenever a sync tick is received on the CAN bus. The driver
+ * extrapolates time locally between updates so blinking continues on slaves.
+ * Re-call periodically to stay in phase across boards.
  */
 void LED_SetSyncTick(uint32_t tick);
 

--- a/LED/README.md
+++ b/LED/README.md
@@ -23,7 +23,22 @@ statusLed.GPIO_Pin = GPIO_PIN_5;  // Replace with your GPIO pin
 LED_ChangeState(&statusLed, LED_BLINK);  // Set LED to blink when everything is fine
 ```
 
-### 3. Handle LED in Main Loop
+### 3. Increment `syncTick` in `HAL_IncTick`
+
+The LED driver uses an internal `syncTick` counter for blink phase timing.  
+You should increment it in `HAL_IncTick()` every 1 ms:
+
+```c
+#include "led_driver.h"
+
+void HAL_IncTick(void)
+{
+    uwTick += uwTickFreq;
+    LED_IncSyncTick();
+}
+```
+
+### 4. Handle LED in Main Loop
 
 Call `LED_Handle()` periodically in your main loop or timer interrupt:
 
@@ -51,4 +66,11 @@ int main(void) {
 
 - Ensure GPIO pins are configured as output in your STM32CubeMX or initialization code
 - `LED_Handle()` should be called frequently enough to maintain blink timing
-- The driver uses `HAL_GetTick()` for timing, so ensure HAL is initialized
+- `LED_IncSyncTick()` must be called from `HAL_IncTick()` to keep blinking running
+- For CAN synchronization on a **slave**, call `LED_SetSyncTick(receivedTick)` when a sync frame is received
+- On the **master**, you can periodically send the current tick with:
+
+```c
+uint32_t tick = LED_GetSyncTick();
+memcpy(txData, &tick, sizeof(tick));  // adjust endianness/layout for your CAN protocol
+```

--- a/LED/Src/led_driver.c
+++ b/LED/Src/led_driver.c
@@ -1,31 +1,41 @@
 #include "led_driver.h"
 
+static uint32_t s_syncTick;
+static uint8_t s_syncTickValid;
+
+static void LED_ApplyBlinkState(struct LED *led, uint32_t interval, uint32_t tick)
+{
+    const uint32_t pos = tick % (2u * interval);
+    const GPIO_PinState pinState = (pos < interval) ? GPIO_PIN_SET : GPIO_PIN_RESET;
+    HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, pinState);
+}
+
+void LED_SetSyncTick(uint32_t tick)
+{
+    s_syncTick = tick;
+    s_syncTickValid = 1;
+}
+
 void LED_Handle(struct LED *led)
 {
-    const uint32_t currentTick = HAL_GetTick();
+    const uint32_t tick = s_syncTickValid ? s_syncTick : HAL_GetTick();
     switch(led->state)
     {
         case LED_OFF:
         case LED_ON:
         break;
         case LED_FAST_BLINK:
-            if((currentTick - led->lastTick) >= LED_FAST_BLINK)
-            {
-                HAL_GPIO_TogglePin(led->GPIO_Port, led->GPIO_Pin);
-                led->lastTick = currentTick;
-            }
+            LED_ApplyBlinkState(led, LED_FAST_BLINK, tick);
             break;
         case LED_BLINK:
-            if((currentTick - led->lastTick) >= LED_BLINK)
-            {
-                HAL_GPIO_TogglePin(led->GPIO_Port, led->GPIO_Pin);
-                led->lastTick = currentTick;
-            }
+            LED_ApplyBlinkState(led, LED_BLINK, tick);
+            break;
     }
 }
 
 void LED_ChangeState(struct LED *led, LED_STATE_e state)
 {
+    const uint32_t tick = s_syncTickValid ? s_syncTick : HAL_GetTick();
     led->state = state;
     switch(led->state)
     {
@@ -33,10 +43,13 @@ void LED_ChangeState(struct LED *led, LED_STATE_e state)
             HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, GPIO_PIN_RESET);
             break;
         case LED_FAST_BLINK:
+            LED_ApplyBlinkState(led, LED_FAST_BLINK, tick);
+            break;
         case LED_BLINK:
+            LED_ApplyBlinkState(led, LED_BLINK, tick);
+            break;
         case LED_ON:
             HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, GPIO_PIN_SET);
-            led->lastTick = HAL_GetTick();
         break;
     }
 }

--- a/LED/Src/led_driver.c
+++ b/LED/Src/led_driver.c
@@ -1,7 +1,18 @@
 #include "led_driver.h"
 
 static uint32_t s_syncTick;
+static uint32_t s_syncLocalTick;
 static uint8_t s_syncTickValid;
+
+static uint32_t LED_GetBlinkTick(void)
+{
+    if (!s_syncTickValid)
+    {
+        return HAL_GetTick();
+    }
+
+    return s_syncTick + (HAL_GetTick() - s_syncLocalTick);
+}
 
 static void LED_ApplyBlinkState(struct LED *led, uint32_t interval, uint32_t tick)
 {
@@ -13,12 +24,13 @@ static void LED_ApplyBlinkState(struct LED *led, uint32_t interval, uint32_t tic
 void LED_SetSyncTick(uint32_t tick)
 {
     s_syncTick = tick;
+    s_syncLocalTick = HAL_GetTick();
     s_syncTickValid = 1;
 }
 
 void LED_Handle(struct LED *led)
 {
-    const uint32_t tick = s_syncTickValid ? s_syncTick : HAL_GetTick();
+    const uint32_t tick = LED_GetBlinkTick();
     switch(led->state)
     {
         case LED_OFF:
@@ -35,7 +47,7 @@ void LED_Handle(struct LED *led)
 
 void LED_ChangeState(struct LED *led, LED_STATE_e state)
 {
-    const uint32_t tick = s_syncTickValid ? s_syncTick : HAL_GetTick();
+    const uint32_t tick = LED_GetBlinkTick();
     led->state = state;
     switch(led->state)
     {

--- a/LED/Src/led_driver.c
+++ b/LED/Src/led_driver.c
@@ -9,14 +9,14 @@ void LED_Handle(struct LED *led)
         case LED_ON:
         break;
         case LED_FAST_BLINK:
-            if(led->lastTick + LED_FAST_BLINK < currentTick)
+            if((currentTick - led->lastTick) >= LED_FAST_BLINK)
             {
                 HAL_GPIO_TogglePin(led->GPIO_Port, led->GPIO_Pin);
                 led->lastTick = currentTick;
             }
             break;
         case LED_BLINK:
-            if(led->lastTick + LED_BLINK < currentTick)
+            if((currentTick - led->lastTick) >= LED_BLINK)
             {
                 HAL_GPIO_TogglePin(led->GPIO_Port, led->GPIO_Pin);
                 led->lastTick = currentTick;

--- a/LED/Src/led_driver.c
+++ b/LED/Src/led_driver.c
@@ -1,16 +1,10 @@
 #include "led_driver.h"
 
-static uint32_t s_syncTick;
-static uint32_t s_syncLocalTick;
-static uint8_t s_syncTickValid;
+static uint32_t s_syncTick = 0;
+static uint32_t s_syncLocalTick = 0;
 
 static uint32_t LED_GetBlinkTick(void)
 {
-    if (!s_syncTickValid)
-    {
-        return HAL_GetTick();
-    }
-
     return s_syncTick + (HAL_GetTick() - s_syncLocalTick);
 }
 
@@ -18,7 +12,10 @@ static void LED_ApplyBlinkState(struct LED *led, uint32_t interval, uint32_t tic
 {
     const uint32_t pos = tick % (2u * interval);
     const GPIO_PinState pinState = (pos < interval) ? GPIO_PIN_SET : GPIO_PIN_RESET;
-    HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, pinState);
+    if(interval != led->state)
+    {
+        HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, pinState);
+    }
 }
 
 void LED_SetSyncTick(uint32_t tick)

--- a/LED/Src/led_driver.c
+++ b/LED/Src/led_driver.c
@@ -1,64 +1,62 @@
 #include "led_driver.h"
 
-static uint32_t s_syncTick = 0;
-static uint32_t s_syncLocalTick = 0;
+static uint32_t syncTick = 0;
 
-static uint32_t LED_GetBlinkTick(void)
+void LED_IncSyncTick(void)
 {
-    return s_syncTick + (HAL_GetTick() - s_syncLocalTick);
-}
-
-static void LED_ApplyBlinkState(struct LED *led, uint32_t interval, uint32_t tick)
-{
-    const uint32_t pos = tick % (2u * interval);
-    const GPIO_PinState pinState = (pos < interval) ? GPIO_PIN_SET : GPIO_PIN_RESET;
-    if(interval != led->state)
-    {
-        HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, pinState);
-    }
+    syncTick++;
 }
 
 void LED_SetSyncTick(uint32_t tick)
 {
-    s_syncTick = tick;
-    s_syncLocalTick = HAL_GetTick();
-    s_syncTickValid = 1;
+    syncTick = tick;
+}
+
+uint32_t LED_GetSyncTick(void)
+{
+    return syncTick;
+}
+
+static void LED_ApplyBlinkState(struct LED *led, uint32_t interval)
+{
+    const uint32_t pos = syncTick % (2u * interval);
+    const GPIO_PinState pinState = (pos < interval) ? GPIO_PIN_SET : GPIO_PIN_RESET;
+    HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, pinState);
 }
 
 void LED_Handle(struct LED *led)
 {
-    const uint32_t tick = LED_GetBlinkTick();
-    switch(led->state)
+    switch (led->state)
     {
         case LED_OFF:
         case LED_ON:
-        break;
+            break;
         case LED_FAST_BLINK:
-            LED_ApplyBlinkState(led, LED_FAST_BLINK, tick);
+            LED_ApplyBlinkState(led, LED_FAST_BLINK);
             break;
         case LED_BLINK:
-            LED_ApplyBlinkState(led, LED_BLINK, tick);
+            LED_ApplyBlinkState(led, LED_BLINK);
             break;
     }
 }
 
 void LED_ChangeState(struct LED *led, LED_STATE_e state)
 {
-    const uint32_t tick = LED_GetBlinkTick();
     led->state = state;
-    switch(led->state)
+
+    switch (led->state)
     {
         case LED_OFF:
             HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, GPIO_PIN_RESET);
             break;
         case LED_FAST_BLINK:
-            LED_ApplyBlinkState(led, LED_FAST_BLINK, tick);
+            LED_ApplyBlinkState(led, LED_FAST_BLINK);
             break;
         case LED_BLINK:
-            LED_ApplyBlinkState(led, LED_BLINK, tick);
+            LED_ApplyBlinkState(led, LED_BLINK);
             break;
         case LED_ON:
             HAL_GPIO_WritePin(led->GPIO_Port, led->GPIO_Pin, GPIO_PIN_SET);
-        break;
+            break;
     }
 }


### PR DESCRIPTION
LED_driver now includes a feature that allows a sync between ecus. One of which needs to transmit frame with their current tick. (For now it will be safestate)

**PYTANIE**
Czy jest sens zeby to było w led driverze, czy lepiej to rozdzielić jakoś?